### PR TITLE
fix: remifentanilo bolo bug is fixed

### DIFF
--- a/src/app/components/drug-form/index.jsx
+++ b/src/app/components/drug-form/index.jsx
@@ -53,7 +53,7 @@ const DrugForm = ({ handleOnAddDrug, selectedDrugs }) => {
     if (drug.bolo && isBolo && drug.bolo.unique) {
       element.bolo = { ...drug.bolo, value: bolo };
     }
-    if (drug.bolo && !isBoloTimeDisabled && isBolo) {
+    if (!isBoloTimeDisabled && isBolo) {
       element.bolo = { ...drug.bolo, value: bolo, boloTime: boloTime };
     }
     if (isDose) {
@@ -207,7 +207,7 @@ const DrugForm = ({ handleOnAddDrug, selectedDrugs }) => {
                 message: "El tiempo debe ser mayor a 0",
               },
             }}
-            disabled={isBoloTimeDisabled || !drug || !isBolo}
+            disabled={isBoloTimeDisabled || !isBolo}
             defaultValue="0"
             render={({ field }) => (
               // Not all drugs has time so we hide errors when the field is disabled

--- a/src/app/components/drug-form/index.jsx
+++ b/src/app/components/drug-form/index.jsx
@@ -53,7 +53,7 @@ const DrugForm = ({ handleOnAddDrug, selectedDrugs }) => {
     if (drug.bolo && isBolo && drug.bolo.unique) {
       element.bolo = { ...drug.bolo, value: bolo };
     }
-    if (!isBoloTimeDisabled && drug.bolo) {
+    if (drug.bolo && !isBoloTimeDisabled && isBolo) {
       element.bolo = { ...drug.bolo, value: bolo, boloTime: boloTime };
     }
     if (isDose) {
@@ -207,7 +207,7 @@ const DrugForm = ({ handleOnAddDrug, selectedDrugs }) => {
                 message: "El tiempo debe ser mayor a 0",
               },
             }}
-            disabled={isBoloTimeDisabled}
+            disabled={isBoloTimeDisabled || !drug || !isBolo}
             defaultValue="0"
             render={({ field }) => (
               // Not all drugs has time so we hide errors when the field is disabled


### PR DESCRIPTION
Cuando se seleccionaba la droga Remifentanilo y se quitaba el bolo del form (se destildaba el checkbox bolo) aun seguia pidiendo el tiempo de bolo. Y cuando se presupuestaba figuraba con undefined y NaN lo cual impedia realizar el presupuesto final.